### PR TITLE
fix: update/streamline Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:latest
-MAINTAINER Shamal Faily <admin@cairis.org>
+LABEL maintainer="Shamal Faily <admin@cairis.org>"
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:latest
 LABEL maintainer="Shamal Faily <admin@cairis.org>"
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y build-essential \
+RUN apt-get update && apt-get install -y build-essential \
     python3-dev \
     mysql-client \ 
     graphviz \
@@ -22,21 +21,17 @@ RUN apt-get install -y build-essential \
     apt-transport-https \
     ca-certificates
 
-RUN pip3 install wheel --break-system-packages
-#Installing Python modules
-COPY docker/requirements.txt /
-RUN pip3 install -r requirements.txt --break-system-packages
-COPY docker/wsgi_requirements.txt /
+COPY docker/requirements.txt docker/wsgi_requirements.txt /
+RUN pip3 install wheel --break-system-packages \
+    && pip3 install -r requirements.txt --break-system-packages
 RUN pip3 install -r wsgi_requirements.txt --break-system-packages
 
-#Environment Variable starts from here
-ENV CAIRIS_SRC=/cairis/cairis
-ENV CAIRIS_CFG_DIR=/cairis/docker
-ENV CAIRIS_CFG=/cairis.cnf
-ENV PYTHONPATH=/cairis
+ENV CAIRIS_SRC=/cairis/cairis \
+    CAIRIS_CFG_DIR=/cairis/docker \
+    CAIRIS_CFG=/cairis.cnf \
+    PYTHONPATH=/cairis
 
-RUN mkdir /tmpDocker
-RUN mkdir /images
+RUN mkdir /tmpDocker /images
 
 #Clonning the repo
 RUN git clone --depth 1 -b master https://github.com/cairis-platform/cairis /cairis
@@ -47,17 +42,19 @@ RUN mkdir /cairisTmp &&\
     rm -rf /cairis/ &&\
     mv /cairisTmp/ /cairis/
 
-COPY docker/cairis.cnf /
-COPY docker/setupDb.sh /
-COPY docker/createdb.sql /
-COPY docker/addAccount.sh /
+COPY \
+    docker/cairis.cnf \
+    docker/setupDb.sh \
+    docker/createdb.sql \
+    docker/addAccount.sh \
+    /
 COPY docker/register_user.html /cairis/cairis/daemon/templates/security
 
-RUN /cairis/cairis/bin/installUI.sh
+RUN /cairis/cairis/bin/installUI.sh \
+    && apt-get remove --purge -y git \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8000
-
-RUN apt-get remove --purge -y git
-RUN apt-get autoremove -y
 
 CMD ["./setupDb.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,27 @@
-FROM ubuntu:latest
+FROM debian:bookworm-slim
+# Pin to Bookworm (Python 3.11). CAIRIS uses imghdr, which was removed in Python 3.13+.
 LABEL maintainer="Shamal Faily <admin@cairis.org>"
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y build-essential \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
     python3-dev \
-    mysql-client \ 
+    default-mysql-client \
     graphviz \
     python3-pip \
     python3-numpy \
     python3-mysqldb \
     git \
     default-libmysqlclient-dev \
-    python3-apt \
     libxml2-dev \
     libxslt1-dev \
     libssl-dev \
+    libmagic1 \
     apache2 \
     apache2-dev \
     poppler-utils \
     python3-setuptools \
-    apt-transport-https \
-    ca-certificates
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY docker/requirements.txt docker/wsgi_requirements.txt /
 RUN pip3 install wheel --break-system-packages \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,13 @@ COPY \
     docker/createdb.sql \
     docker/addAccount.sh \
     /
+COPY cairis/bin/installUI.sh /cairis/cairis/bin/installUI.sh
 COPY docker/register_user.html /cairis/cairis/daemon/templates/security
 
-RUN /cairis/cairis/bin/installUI.sh \
-    && apt-get remove --purge -y git \
+RUN chmod +x /cairis/cairis/bin/installUI.sh \
+    && /cairis/cairis/bin/installUI.sh
+
+RUN apt-get remove --purge -y git \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/cairis/bin/installUI.sh
+++ b/cairis/bin/installUI.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -x
+#!/bin/bash
+set -euo pipefail
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -19,14 +20,15 @@
 # Author: Shamal Faily
 
 export UI_REPO=/tmp/cairis-ui
-rm -rf $UI_REPO
-apt-get install curl
-curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-apt-get update && apt-get install -y yarn
-apt-get install -y yarn
-git clone https://github.com/cairis-platform/cairis-ui $UI_REPO
-yarn --cwd $UI_REPO install --ignore-engines
-yarn --cwd $UI_REPO run build
-cp -r $UI_REPO/dist $CAIRIS_SRC
+rm -rf "$UI_REPO"
+
+apt-get update
+apt-get install -y curl ca-certificates gnupg
+curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+apt-get install -y nodejs
+npm install -g yarn
+
+git clone https://github.com/cairis-platform/cairis-ui "$UI_REPO"
+yarn --cwd "$UI_REPO" install --ignore-engines
+yarn --cwd "$UI_REPO" run build
+cp -r "$UI_REPO/dist" "$CAIRIS_SRC"

--- a/cairis/bin/installUI.sh
+++ b/cairis/bin/installUI.sh
@@ -13,10 +13,10 @@
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 #  KIND, either express or implied.  See the License for the
-#  specific language go
-#
-# Author: Shamal Faily
+#  specific language governing permissions and limitations
+#  under the License.
 
+# Author: Shamal Faily
 
 export UI_REPO=/tmp/cairis-ui
 rm -rf $UI_REPO


### PR DESCRIPTION
## Summary

- Replace deprecated `MAINTAINER` with `LABEL maintainer=...`
- Reduce Dockerfile layers by merging apt install, COPY, ENV, and cleanup steps
- Restore truncated Apache license header in `cairis/bin/installUI.sh`
- Replace broken `apt-key` Yarn install with `npm install -g yarn` in `installUI.sh`; copy the fixed script into the image after cloning CAIRIS
- Pin base image to `debian:bookworm-slim` (Python 3.11) because CAIRIS still imports `imghdr`, which was removed in Python 3.13+ on `ubuntu:latest`

## Test plan

- [x] `docker build -t cairis:local .` completes successfully
- [x] Container starts with MySQL and serves login page on mapped port
- [x] Login works after creating a user via `/addAccount.sh`
- [ ] Upstream maintainer review of base image change (`ubuntu:latest` → `debian:okworm-slim`)

Co-authored-by AI